### PR TITLE
feat(model-ad): match collection names to data release collection names (MG-325)

### DIFF
--- a/create-indexes.js
+++ b/create-indexes.js
@@ -6,25 +6,25 @@ print('');
 
 const collections = [
     {
-        name: 'modeldetails',
+        name: 'model_details',
         indexes: [
             { model: 1 },
         ]
     },
     {
-        name: 'uiconfig',
+        name: 'ui_config',
         indexes: [
             { page: 1 },
         ]
     },
     {
-        name: 'modeloverview',
+        name: 'model_overview',
         indexes: [
             { model: 1 },
         ]
     },
     {
-        name: 'diseasecorrelation',
+        name: 'disease_correlation',
         indexes: [
             { model: 1 },
         ]

--- a/import-data.sh
+++ b/import-data.sh
@@ -49,10 +49,10 @@ fi
 # Import synapse data to database
 # Not using --mode upsert for now because we don't have unique indexes properly set for the collections
 
-mongoimport -h $DB_HOST -d model-ad -u $DB_USER -p $DB_PASS --authenticationDatabase admin --collection modeldetails --jsonArray --drop --file $DATA_DIR/model_details.json
-mongoimport -h $DB_HOST -d model-ad -u $DB_USER -p $DB_PASS --authenticationDatabase admin --collection uiconfig --jsonArray --drop --file $DATA_DIR/ui_config.json
-mongoimport -h $DB_HOST -d model-ad -u $DB_USER -p $DB_PASS --authenticationDatabase admin --collection modeloverview --jsonArray --drop --file $DATA_DIR/model_overview.json
-mongoimport -h $DB_HOST -d model-ad -u $DB_USER -p $DB_PASS --authenticationDatabase admin --collection diseasecorrelation --jsonArray --drop --file $DATA_DIR/disease_correlation.json
+mongoimport -h $DB_HOST -d model-ad -u $DB_USER -p $DB_PASS --authenticationDatabase admin --collection model_details --jsonArray --drop --file $DATA_DIR/model_details.json
+mongoimport -h $DB_HOST -d model-ad -u $DB_USER -p $DB_PASS --authenticationDatabase admin --collection ui_config --jsonArray --drop --file $DATA_DIR/ui_config.json
+mongoimport -h $DB_HOST -d model-ad -u $DB_USER -p $DB_PASS --authenticationDatabase admin --collection model_overview --jsonArray --drop --file $DATA_DIR/model_overview.json
+mongoimport -h $DB_HOST -d model-ad -u $DB_USER -p $DB_PASS --authenticationDatabase admin --collection disease_correlation --jsonArray --drop --file $DATA_DIR/disease_correlation.json
 
 echo "Importing dataversion from ${DATAVERSION_PATH}"
 mongoimport -h $DB_HOST -d model-ad -u $DB_USER -p $DB_PASS --authenticationDatabase admin --collection dataversion $DATAVERSION_FLAG --drop --file $DATAVERSION_PATH


### PR DESCRIPTION
## Description
This PR modifies the import process to use the collection name defined in Synapse.

## Related Issue

[MG325](https://sagebionetworks.jira.com/browse/MG-325)

## Changelog
- Update collection names to include underscores