### PR TITLE
MG-322: use name instead of model for indexes

### DIFF
--- a/create-indexes.js
+++ b/create-indexes.js
@@ -8,7 +8,7 @@ const collections = [
     {
         name: 'model_details',
         indexes: [
-            { model: 1 },
+            { name: 1 },
         ]
     },
     {
@@ -20,13 +20,13 @@ const collections = [
     {
         name: 'model_overview',
         indexes: [
-            { model: 1 },
+            { name: 1 },
         ]
     },
     {
         name: 'disease_correlation',
         indexes: [
-            { model: 1 },
+            { name: 1 },
         ]
     }
 ];


### PR DESCRIPTION
We recently released mv70 in [MG-322](https://sagebionetworks.jira.com/browse/MG-322), which included renaming `model` to `name` across collections. We should rename the indexes to match the new field name.

[MG-322]: https://sagebionetworks.jira.com/browse/MG-322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ