### PR TITLE
MG-499: release exploratory data mv91, import rna_de_aggregate collection

### DIFF
--- a/create-indexes.js
+++ b/create-indexes.js
@@ -28,6 +28,12 @@ const collections = [
         indexes: [
             { name: 1 },
         ]
+    },
+    {
+        name: "rna_de_aggregate",
+        indexes: [
+            { ensembl_gene_id: 1 }
+        ]
     }
 ];
 

--- a/data-manifest.json
+++ b/data-manifest.json
@@ -1,4 +1,4 @@
 {
-    "data_version": "90",
+    "data_version": "91",
     "data_file": "syn63540270"
 }

--- a/import-data.sh
+++ b/import-data.sh
@@ -21,7 +21,8 @@ readonly COLLECTIONS=(
     "model_details"
     "ui_config"
     "model_overview"
-    "disease_correlation"
+    "disease_correlation",
+    "rna_de_aggregate"
 )
 
 # Database Configuration


### PR DESCRIPTION
Push mv91 into develop and import `rna_de_aggregate` collection. See [MG-499](https://sagebionetworks.jira.com/browse/MG-499).

[MG-499]: https://sagebionetworks.jira.com/browse/MG-499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ