### PR TITLE
MG-499: remove unneeded comma

### DIFF
--- a/import-data.sh
+++ b/import-data.sh
@@ -21,7 +21,7 @@ readonly COLLECTIONS=(
     "model_details"
     "ui_config"
     "model_overview"
-    "disease_correlation",
+    "disease_correlation"
     "rna_de_aggregate"
 )
 


### PR DESCRIPTION
Fixes bug introduced by #14, which added an unneeded comma to disease_correlation in the import-data config. The bug caused this failure: https://github.com/Sage-Bionetworks/model-ad-data-manager/actions/runs/19311126530