### PR TITLE
MG-499: use mongoimport --drop instead of separate mongo drop command to attempt to fix failure for disease_correlation collection

### DIFF
--- a/utils/database-utils.sh
+++ b/utils/database-utils.sh
@@ -102,10 +102,8 @@ import_collection() {
     fi
 
     log "Replacing collection: $collection from $file"
-    # Drop just this collection to ensure clean state
-    mongosh "$mongo_uri" --username "$mongo_user" --password "$mongo_pass" --eval "db.getCollection('$collection').drop()" >/dev/null 2>&1
-
-    if ! mongoimport --uri="$mongo_uri" --username "$mongo_user" --password "$mongo_pass" --collection "$collection" $flags --file "$file"; then
+    # Use --drop flag to let mongoimport handle dropping the collection if it exists
+    if ! mongoimport --uri="$mongo_uri" --username "$mongo_user" --password "$mongo_pass" --collection "$collection" --drop $flags --file "$file"; then
         error "Failed to import collection $collection"
         exit 1
     fi


### PR DESCRIPTION
Attempts to fix [failure](https://github.com/Sage-Bionetworks/model-ad-data-manager/actions/runs/19311334636/job/55232077206) to import `disease_correlation` collection after merging #15. Suspect that there was an issue with the `drop()` operation since `disease_correlation` collection was removed after merging #14, then re-added in #15. Try using a more idiomatic approach using `--drop` flag to let `mongoimport` handle dropping the collection if it exists, rather than two operations.