### PR TITLE
MG-499: remove rna_de_aggregate until collection is updated to be valid JSON

### DIFF
--- a/import-data.sh
+++ b/import-data.sh
@@ -22,7 +22,6 @@ readonly COLLECTIONS=(
     "ui_config"
     "model_overview"
     "disease_correlation"
-    "rna_de_aggregate"
 )
 
 # Database Configuration


### PR DESCRIPTION
We [failed](https://github.com/Sage-Bionetworks/model-ad-data-manager/actions/runs/19312410223) to import documents into the `rna_de_aggregate` collection in the last workflow run because the documents are not valid JSON -- there are some `adj_p_val` fields where the value is `NaN`. After the data has been updated to be valid JSON, we can add this collection.