### PR TITLE
MG-568: bump to mv96, add collection indexes for composite ids

### DIFF
--- a/create-indexes.js
+++ b/create-indexes.js
@@ -27,12 +27,14 @@ const collections = [
         name: 'disease_correlation',
         indexes: [
             { name: 1 },
+            { cluster: 1, name: 1, age: 1, sex: 1 },
         ]
     },
     {
         name: "rna_de_aggregate",
         indexes: [
-            { ensembl_gene_id: 1 }
+            { ensembl_gene_id: 1 },
+            { tissue: 1, sex_cohort: 1, ensembl_gene_id: 1, name: 1 },
         ]
     }
 ];

--- a/data-manifest.json
+++ b/data-manifest.json
@@ -1,4 +1,4 @@
 {
-    "data_version": "95",
+    "data_version": "96",
     "data_file": "syn63540270"
 }


### PR DESCRIPTION
Release mv96 to dev. Add collection indexes for composite ids to Disease Correlation and Gene Expression collections.

[MG-568](https://sagebionetworks.jira.com/browse/MG-568)

> [!IMPORTANT]
> Release should be coordinated with update to code in https://github.com/Sage-Bionetworks/sage-monorepo/pull/3742

[MG-568]: https://sagebionetworks.jira.com/browse/MG-568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ