### PR TITLE
MG-662: release exploratory data mv101, add rna_de_individual collection and indexes, MG-621: match insertion order to source file order for ui_config

### DIFF
--- a/create-indexes.js
+++ b/create-indexes.js
@@ -36,6 +36,13 @@ const collections = [
             { ensembl_gene_id: 1 },
             { tissue: 1, sex_cohort: 1, ensembl_gene_id: 1, name: 1 },
         ]
+    },
+    {
+        name: "rna_de_individual",
+        indexes: [
+            { ensembl_gene_id: 1 },
+            { ensembl_gene_id: 1, tissue: 1, name: 1, model_group: 1 },
+        ]
     }
 ];
 

--- a/data-manifest.json
+++ b/data-manifest.json
@@ -1,4 +1,4 @@
 {
-    "data_version": "98",
+    "data_version": "101",
     "data_file": "syn63540270"
 }

--- a/import-data.sh
+++ b/import-data.sh
@@ -22,7 +22,8 @@ readonly COLLECTIONS=(
     "ui_config"
     "model_overview"
     "disease_correlation"
-    "rna_de_aggregate"
+    "rna_de_aggregate",
+    "rna_de_individual"
 )
 
 # Database Configuration

--- a/utils/database-utils.sh
+++ b/utils/database-utils.sh
@@ -103,7 +103,8 @@ import_collection() {
 
     log "Replacing collection: $collection from $file"
     # Use --drop flag to let mongoimport handle dropping the collection if it exists
-    if ! mongoimport --uri="$mongo_uri" --username "$mongo_user" --password "$mongo_pass" --collection "$collection" --drop $flags --file "$file"; then
+    # Use --maintainInsertionOrder to insert documents in the order they appear in the file
+    if ! mongoimport --uri="$mongo_uri" --username "$mongo_user" --password "$mongo_pass" --collection "$collection" --drop $flags --file "$file" --maintainInsertionOrder; then
         error "Failed to import collection $collection"
         exit 1
     fi

--- a/utils/database-utils.sh
+++ b/utils/database-utils.sh
@@ -102,9 +102,15 @@ import_collection() {
     fi
 
     log "Replacing collection: $collection from $file"
+
+    # Use --maintainInsertionOrder for ui_config to preserve order of UI elements
+    local order_flag=""
+    if [ "$collection" = "ui_config" ]; then
+        order_flag="--maintainInsertionOrder"
+    fi
+
     # Use --drop flag to let mongoimport handle dropping the collection if it exists
-    # Use --maintainInsertionOrder to insert documents in the order they appear in the file
-    if ! mongoimport --uri="$mongo_uri" --username "$mongo_user" --password "$mongo_pass" --collection "$collection" --drop $flags --file "$file" --maintainInsertionOrder; then
+    if ! mongoimport --uri="$mongo_uri" --username "$mongo_user" --password "$mongo_pass" --collection "$collection" --drop $flags --file "$file" $order_flag; then
         error "Failed to import collection $collection"
         exit 1
     fi


### PR DESCRIPTION
Push mv101 into develop. Add `rna_de_individual` collection and indexes. See [MG-662](https://sagebionetworks.jira.com/browse/MG-662).

Match insertion order to source file order for `ui_config`. See [MG-621](https://sagebionetworks.jira.com/browse/MG-621).

> [!WARNING]
> Merge should be coordinated with https://github.com/Sage-Bionetworks/sage-monorepo/pull/3788.

[MG-662]: https://sagebionetworks.jira.com/browse/MG-662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MG-621]: https://sagebionetworks.jira.com/browse/MG-621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ