### PR TITLE
Update to deploy mv1 from prod data folder

### DIFF
--- a/data-manifest.json
+++ b/data-manifest.json
@@ -1,4 +1,4 @@
 {
-  "data_version": "8",
-  "data_file": "syn73774820"
+  "data_version": "1",
+  "data_file": "syn74702351"
 }


### PR DESCRIPTION
This PR updates the model-ad-data-manager for production launch:

- Deploy data from the production folder, rather than the preprod folder
- Deploy our validated production data release